### PR TITLE
Add deployment instructions and workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+name: Deploy static site
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/upload-pages-artifact@v2
+        with:
+          path: .
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v2

--- a/README.md
+++ b/README.md
@@ -1,0 +1,51 @@
+# ALF25 Static Site
+
+This repository contains the static assets for the Amsterdam Light Festival 2025 website.
+
+## Local development
+
+No build step is required. The site consists of static HTML and images. To preview the site locally you can use any static file server, for example:
+
+```bash
+python3 -m http.server 8000
+```
+
+The site will be available at <http://localhost:8000>.
+
+### Environment variables
+
+The booking form expects the following variables to be available:
+
+- `BOOKING_API_URL` – API endpoint where form submissions are sent.
+- `BOOKING_API_KEY` – secret key for authenticating with the booking API.
+
+When testing locally, set them in your shell before starting the server:
+
+```bash
+export BOOKING_API_URL=https://api.example.com/book
+export BOOKING_API_KEY=your_api_key
+python3 -m http.server 8000
+```
+
+On hosting platforms such as Netlify or GitHub Pages, configure these values in the platform's environment/secret settings.
+
+## Deployment
+
+### GitHub Pages
+
+1. Push changes to the `main` branch.
+2. The included GitHub Actions workflow (`.github/workflows/deploy.yml`) builds and deploys the site to GitHub Pages automatically.
+3. Enable Pages in the repository settings if it has not been enabled.
+
+### Netlify
+
+1. Connect the repository to Netlify.
+2. Set `BOOKING_API_URL` and `BOOKING_API_KEY` in **Site settings → Build & deploy → Environment**.
+3. Deploy using the Netlify UI or via the CLI:
+
+```bash
+netlify deploy --prod
+```
+
+No build command is required; the publish directory is the repository root.
+


### PR DESCRIPTION
## Summary
- document local development and deployment, including environment variables for the booking form
- add GitHub Actions workflow to deploy static site to GitHub Pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f531d5f4832cb1a6dc4196db3587