### PR TITLE
Improve iPhone viewport and safe area

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="nl" class="scroll-smooth">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <meta name="description" content="Gezellige boottocht tijdens het Amsterdam Light Festival. Jij regelt de mensen, wij de rest." />
   <title>ALF25 Canal Cruise</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.css" />
@@ -172,7 +172,7 @@
   </main>
 
   <!-- Sticky contact bar -->
-  <div class="fixed inset-x-0 bottom-0 md:inset-auto md:bottom-auto md:right-4 md:top-4 flex justify-around md:flex-col bg-white/90 md:bg-transparent p-2 md:space-y-2" aria-label="Snelle contact opties">
+  <div class="fixed inset-x-0 bottom-0 md:inset-auto md:bottom-auto md:right-4 md:top-4 flex justify-around md:flex-col bg-white/90 md:bg-transparent p-2 md:space-y-2" aria-label="Snelle contact opties" style="padding-bottom: calc(env(safe-area-inset-bottom) + 0.5rem); padding-left: calc(env(safe-area-inset-left) + 0.5rem); padding-right: calc(env(safe-area-inset-right) + 0.5rem);">
     <a href="https://wa.me/31612345678" class="flex-1 text-center bg-sky-500 text-white rounded-2xl mx-1 px-4 py-2 focus:outline-none focus:ring" aria-label="WhatsApp">WhatsApp</a>
     <a href="tel:+31612345678" class="flex-1 text-center bg-black text-white rounded-2xl mx-1 px-4 py-2 focus:outline-none focus:ring" aria-label="Bel">Bel</a>
     <a href="mailto:bookings@canalstartup.nl" class="flex-1 text-center bg-slate-200 text-black rounded-2xl mx-1 px-4 py-2 focus:outline-none focus:ring" aria-label="E-mail">E-mail</a>


### PR DESCRIPTION
## Summary
- Allow full screen coverage on iPhones by adding `viewport-fit=cover` to the viewport meta tag.
- Prevent sticky contact bar from being obscured by iPhone safe areas.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7fa0f9bb8832cac3a326b39830655