### PR TITLE
Add promotional section with price and WhatsApp CTA

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,13 +48,21 @@
           <a href="tel:+31612345678" class="bg-slate-200 text-black rounded-2xl px-6 py-3 focus:outline-none focus:ring" aria-label="Bel ons">Bel ons</a>
         </div>
       </div>
-    </section>
+      </section>
 
-    <!-- Highlights -->
-    <section class="py-24" aria-labelledby="usp-heading">
-      <h2 id="usp-heading" class="sr-only">Highlights</h2>
-      <div class="max-w-6xl mx-auto grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-6 text-center">
-        <div class="p-6 ring-1 ring-black/5 rounded-lg">Tot <strong>55 personen</strong></div>
+      <!-- Introductie en promotie -->
+      <section class="py-16 text-center" aria-labelledby="intro-heading">
+        <h2 id="intro-heading" class="text-3xl font-semibold mb-4">Privé tocht langs het Light Festival</h2>
+        <p class="max-w-2xl mx-auto mb-6">Stap aan boord met je vrienden of collega's en beleef alle lichtkunst vanaf het water. Wij regelen schipper, dekens en drankjes.</p>
+        <p class="text-xl md:text-2xl mb-6"><strong>€550 all-in tot 11 personen</strong></p>
+        <a href="https://wa.me/31612345678?text=Ik%20wil%20een%20boottocht%20boeken" class="inline-block bg-sky-500 text-white rounded-2xl px-6 py-3 focus:outline-none focus:ring">Stuur me een appje</a>
+      </section>
+
+      <!-- Highlights -->
+      <section class="py-24" aria-labelledby="usp-heading">
+        <h2 id="usp-heading" class="sr-only">Highlights</h2>
+        <div class="max-w-6xl mx-auto grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-6 text-center">
+          <div class="p-6 ring-1 ring-black/5 rounded-lg">Tot <strong>55 personen</strong></div>
         <div class="p-6 ring-1 ring-black/5 rounded-lg">Toilet aan boord</div>
         <div class="p-6 ring-1 ring-black/5 rounded-lg">Kussens & speakers</div>
         <div class="p-6 ring-1 ring-black/5 rounded-lg">Grote borreltafel</div>


### PR DESCRIPTION
## Summary
- add intro section after hero with full promotional text
- highlight €550 all-in price and WhatsApp call-to-action

## Testing
- `python3 -m http.server 8000`

------
https://chatgpt.com/codex/tasks/task_e_68c7fac154f8832ca3a485f35e7ac1bf