### PR TITLE
Update pricing section and verify booking timeslots

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,9 +77,9 @@
     <section class="py-24" aria-labelledby="pricing-heading">
       <div class="max-w-3xl mx-auto text-center space-y-4">
         <h2 id="pricing-heading" class="sr-only">Prijzen & data</h2>
-        <p>Vanaf <strong>€45 p.p.</strong> (indicatief)</p>
-        <p>Duur: <strong>90 min</strong></p>
-        <p>Data: <strong>5 dec – 18 jan</strong></p>
+        <p><strong>€550 all-in</strong> (t/m 11 personen)</p>
+        <p>Duur: <strong>1,5 uur</strong></p>
+        <p>Data: <strong>27 nov – 18 jan</strong></p>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- Update "Prijzen & data" section with new price, duration, and dates
- Verified booking form includes 17:30, 19:30, and 21:30 timeslots

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7fac1c328832cbc745f1ccc24697a